### PR TITLE
Add celebrity library filters and custom portrait details

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,20 @@
                         <input type="text" id="celebrityInput" placeholder="Search celebrity name..." autocomplete="off">
                         <div class="celebrity-suggestions" id="celebritySuggestions"></div>
                     </div>
+                    <div class="filters">
+                        <select id="genderFilter">
+                            <option value="">All Genders</option>
+                            <option value="male">Male</option>
+                            <option value="female">Female</option>
+                        </select>
+                        <select id="industryFilter">
+                            <option value="">All Industries</option>
+                            <option value="hollywood">Hollywood</option>
+                            <option value="bollywood">Bollywood</option>
+                            <option value="hiphop">Hip-hop Artists</option>
+                            <option value="singers">Singers</option>
+                        </select>
+                    </div>
                     <div class="popular-celebrities">
                         <h3>Popular Choices:</h3>
                         <div class="celebrity-chips" id="celebrityChips"></div>
@@ -44,6 +58,14 @@
                 <div class="input-card">
                     <h2><i class="fas fa-magic"></i> Theme & Mood</h2>
                     <div class="theme-grid" id="themeGrid"></div>
+                </div>
+
+                <div class="input-card">
+                    <h2><i class="fas fa-user-edit"></i> Custom Details</h2>
+                    <input type="text" id="expressionInput" placeholder="Facial expression (e.g., happy, serious)">
+                    <input type="text" id="outfitInput" placeholder="Outfit and accessories">
+                    <input type="text" id="moodInput" placeholder="Mood or tone">
+                    <input type="text" id="featuresInput" placeholder="Specific features (e.g., long flowing hair)">
                 </div>
 
                 <div class="input-card advanced-options" id="advancedOptions">

--- a/style.css
+++ b/style.css
@@ -78,6 +78,9 @@ body {
   font-size: 1.15rem;
   color: #C063FE;
 }
+.celebrity-input {
+  position: relative;
+}
 .celebrity-input input {
   width: 100%;
   font-size: 1.07rem;
@@ -98,6 +101,26 @@ body {
   background: #fff;
   border: 1px solid #eee;
   border-radius: 0 0 7px 7px;
+  width: 100%;
+}
+.celebrity-suggestions div {
+  padding: 8px 12px;
+  cursor: pointer;
+}
+.celebrity-suggestions div:hover {
+  background: #f5f5f5;
+}
+.filters {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+.filters select {
+  flex: 1;
+  padding: 7px 12px;
+  border: 1px solid #eee;
+  border-radius: 7px;
+  font-size: 0.95rem;
 }
 .celebrity-chips {
   display: flex;


### PR DESCRIPTION
## Summary
- organize celebrity data into gender and industry categories and add filters with live search suggestions
- include optional custom detail fields for expression, outfit, mood and features in prompt generation
- style new filters and suggestion list for smoother selection

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bebf362a948331b4dc347c575b7fd9