### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -708,17 +708,35 @@ body {
 }
 
 @media (max-width: 480px) {
-    .input-card, .output-section {
-        padding: 20px 15px;
+    .top-bar {
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
     }
 
     .header-controls {
         position: static;
         justify-content: center;
-        margin-top: 15px;
+        margin-top: 0.5rem;
+        flex-wrap: wrap;
+        gap: 0.5rem;
     }
 
-.modal-content {
+    .header-controls button {
+        font-size: 0.85rem;
+        padding: 4px 8px;
+    }
+
+    .app-main {
+        gap: 1rem;
+    }
+
+    .input-card,
+    .output-section {
+        padding: 20px 15px;
+    }
+
+    .modal-content {
         width: 95%;
         margin: 10px;
     }


### PR DESCRIPTION
## Summary
- Tweak mobile layout so header controls and main sections stack and wrap for small screens
- Reduce control spacing and font size to prevent overflow on phones

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile script.py script_1.py script_2.py script_3.py script_4.py` *(fails: SyntaxError in script_3.py)*

------
https://chatgpt.com/codex/tasks/task_b_68c1898e055c8331bba6aa4fe0a749c9